### PR TITLE
Mostly styling changes

### DIFF
--- a/src/5-31-2023-log.md
+++ b/src/5-31-2023-log.md
@@ -1,22 +1,50 @@
+# changes
+---
+- Changed code font from `Consolas` to `Fira Code`
+    - Inline code remains as is, i.e. `Ubuntu Mono`
+    - Inline code now has padding and background color
+    - Changed padding for code blocks from `7px` to `5px`
+- Modified the event listener for enter to ensure that Markdown is rendered and saved to file after enter key press
+- Fixed highlighting of Notes tab to only highlight text content by making a list of spans and changed the event listener on `fileList` to look for `if (target.tagName === 'SPAN')` instead of looking for `tagName === 'LI'`
+- Added more auto-closing for `<`, `$`, and `` ` ``
+    - Changed the event listener for auto-closing to utilize `closingCharactersMap` instead of hard-coding all the separate characters
+
 # today's goals
 ---
-- Fix highlighting of Notes tab to only highlight text content 
-    - **APPROACH:** Make the text content a span instead, so Notes tab is a list of spans of text, instead of a list of text
 - Add indentation guides
     - **APPROACH:** Add an `indented` class to any indented text/to list items by utilizing `li::before` and `p::before` properties
 - Fix auto-bracket closing by skipping to next character if the closing bracket is typed by instinct after typing the opening bracket
 - Fix this error `Uncaught TypeError: Cannot read properties of null (reading '0') at HTMLTextAreaElement.<anonymous> (render.js:169:74)`
     - It doesn't break anything just really annoying to see on the console lol
-- Add more auto-closing, such as for `<`, `$`, and `` ` ``
 - Implement a UI for note creation and deletion 
 - Move Notes tab to the left side 
+- Fix the issue that the selection sometimes automatically goes to the last character (hard to recreate... not sure exactly what causes this)
 
 # to-be-implemented
 ---
 - Make rendering dynamic
+- Make the app zoomable
 - UI for note outline (makes note navigable)
 - Read-only mode
 - UI for folder creation, deletion, and renaming
 - Handle image pasting
+    - **APPROACH:** Attach a `paste` event listener to `editor` and check if the pasted data is of type `image`. Then, make a `handleImageFile()` function to upload the image to the system, and obtain the embed HTML. Finally, make an `insertImageAtCursor()` function to preserve cursor position and focus
 - View multiple notes at once
 - Change to rich text Markdown editor
+- Drag and drop notes into folders
+    - **APPROACH:** When a note is created, create `li` element with `draggable="true"` property in the currently selected folder. Then, define drop-zones for folders by making each folder a `div` element, giving it a `class="folder"`, and giving it the `droppable="true"` property.
+        - Add event listeners for `dragover` and `drop` events to each folder. When a note is dragged over a folder, the `dragover` event is triggered, and use `event.preventDefault()` to enable dropping. Finally, when a note is dropped into a folder, the `drop` event is triggered and it retrieves the ID of the dragged note by using `event.dataTransfer.getData()`, finds the corresponding note element, and appends it to the folder 
+        
+# demo
+---
+I really like making inline LaTeX... $\sum_{k = 1}^n \frac{1}{k(k + 1)} = \frac{n}{n + 1}$
+
+I really like making nice looking code blocks using `Atom One Dark` theme...
+```js
+function handleImageFile(file) {
+    // Upload file to the system and get the URL or embed HTML
+    // Insert URL/embed HTML into `editor` 
+    const imageURL = "https://example.com/images/image.jpg";
+    const embedHTML = `<img src="${imageURL}" alt ="Pasted image"/>`;
+    insertTextAtCursor(editor, embedHTML);
+``

--- a/src/index.css
+++ b/src/index.css
@@ -93,9 +93,10 @@ pre {
   border-radius: 6px;
 }
 
-/* wraps code in code block if needed */
 pre code {
-  white-space: pre-wrap;
+  white-space: pre-wrap;      /* wraps code in code block if needed */
+  font-family: 'Fira Code', monospace;
+  font-size: 0.8em;
 }
 
 /* change the appearance of inline code */
@@ -132,7 +133,7 @@ a:visited {
   color: var(--text-a);
 }
 
-.selected {
+#noteList .selected {
   background-color: var(--blockquote-border);
   border-radius: 5px;
   padding: 4px 6px;

--- a/src/render.js
+++ b/src/render.js
@@ -108,38 +108,28 @@ editor.addEventListener('keydown', (event) => {
   }
 });
 
-// Add event listener for bracket key press to autoclose brackets
+// Map of closing characters
+const closingCharactersMap = {
+  '(': ')',
+  '{': '}',
+  '[': ']',
+  '`': '`',
+  '$': '$',
+  '*': '*',
+  '_': '_',
+};
+
+// Add event listener for auto-closing characters defined in closingCharactersMap
 editor.addEventListener('keydown', (event) => {
-  if (event.key === '(') {
+  const { key } = event;
+  const closingBracket = closingCharactersMap[key];
+  
+  if (closingBracket) {
     event.preventDefault();
     const { selectionStart, selectionEnd } = editor;
-    // Insert the closing bracket at current cursor position
-    const closingBracket = ')';
-    const newText = editor.value.substring(0, selectionStart) + event.key + closingBracket + editor.value.substring(selectionEnd);
 
-    // Update the textarea value with the new text and adjust the cursor position
-    editor.value = newText;
-    editor.selectionStart = editor.selectionEnd = selectionStart + closingBracket.length;;
-    renderMarkdown();
-    saveMarkdownToFile();
-  } else if (event.key === '{') {
-    event.preventDefault();
-    const { selectionStart, selectionEnd } = editor;
-    // Insert the closing bracket at current cursor position
-    const closingBracket = '}';
-    const newText = editor.value.substring(0, selectionStart) + event.key + closingBracket + editor.value.substring(selectionEnd);
-
-    // Update the textarea value with the new text and adjust the cursor position
-    editor.value = newText;
-    editor.selectionStart = editor.selectionEnd = selectionStart + closingBracket.length;;
-    renderMarkdown();
-    saveMarkdownToFile();
-  } else if (event.key === '[') {
-    event.preventDefault();
-    const { selectionStart, selectionEnd } = editor;
-    // Insert the closing bracket at current cursor position
-    const closingBracket = ']';
-    const newText = editor.value.substring(0, selectionStart) + event.key + closingBracket + editor.value.substring(selectionEnd);
+    // Insert the closing bracket at the current cursor position
+    const newText = editor.value.substring(0, selectionStart) + key + closingBracket + editor.value.substring(selectionEnd);
 
     // Update the textarea value with the new text and adjust the cursor position
     editor.value = newText;
@@ -158,6 +148,8 @@ editor.addEventListener('keydown', (event) => {
     const indentation = /^\s*/.exec(currentLine)[0];
     const newText = `\n${indentation}`;
     editor.setRangeText(newText, selectionStart, selectionStart, 'end');
+    renderMarkdown();
+    saveMarkdownToFile();
   }
 });
 
@@ -177,6 +169,8 @@ editor.addEventListener('keydown', (event) => {
       editor.setRangeText(newText, selectionStart - currentLine.length, selectionStart, 'end');
       editor.selectionStart = editor.selectionEnd = newSelectionStart;
     }
+    renderMarkdown();
+    saveMarkdownToFile();
   }
 });
 
@@ -196,11 +190,13 @@ const listMDFiles = () => {
     files.forEach((file) => {
       if (file.endsWith('.md')) {
         const li = document.createElement('li');
-        li.textContent = file;
-        li.dataset.filePath = path.join(directoryName, file);     
-        if (selectedFilePath === li.dataset.filePath) {       // if selectedFilePath is equal to the current file path, add the selected class
-          li.classList.add('selected');
+        const span = document.createElement('span');
+        span.textContent = file;
+        span.dataset.filePath = path.join(directoryName, file);
+        if (selectedFilePath === span.dataset.filePath) {       // if selectedFilePath is equal to the current file path, add the selected class
+          span.classList.add('selected');
         }
+        li.appendChild(span);
         fileList.appendChild(li);
       }
     });
@@ -211,7 +207,7 @@ const listMDFiles = () => {
 // and add the selected class to the selected file and remove it from the previously selected file
 fileList.addEventListener('click', (event) => {
   const { target } = event;
-  if (target.tagName === 'LI') {
+  if (target.tagName === 'SPAN') {
     const { filePath } = target.dataset;
     // if filePath exists, set selectedFilePath to filePath and stop watching the previously selected file
     if (filePath) {

--- a/src/test-3rename!.md
+++ b/src/test-3rename!.md
@@ -1,6 +1,0 @@
-blabla text bla `inline code` blabla
-```py
-# this is a code block
-def add(x, y):
-    return x+y
-```


### PR DESCRIPTION
- Changed code font from `Consolas` to `Fira Code`
    - Inline code remains as is, i.e. `Ubuntu Mono`
    - Inline code now has padding and background color
    - Changed padding for code blocks from `7px` to `5px`
- Modified the event listener for enter to ensure that Markdown is rendered and saved to file after enter key press
- Fixed highlighting of Notes tab to only highlight text content by making a list of spans and changed the event listener on `fileList` to look for `if (target.tagName === 'SPAN')` instead of looking for `tagName === 'LI'`
- Added more auto-closing for `<`, `$`, and `` ` ``
    - Changed the event listener for auto-closing brackets to utilize `closingCharactersMap` instead of hard-coding all the separate characters
