### PR TITLE
Sean

### DIFF
--- a/src/5-31-2023-log.md
+++ b/src/5-31-2023-log.md
@@ -6,8 +6,22 @@
     - Changed padding for code blocks from `7px` to `5px`
 - Modified the event listener for enter to ensure that Markdown is rendered and saved to file after enter key press
 - Fixed highlighting of Notes tab to only highlight text content by making a list of spans and changed the event listener on `fileList` to look for `if (target.tagName === 'SPAN')` instead of looking for `tagName === 'LI'`
-- Added more auto-closing for `<`, `$`, and `` ` ``
-    - Changed the event listener for auto-closing to utilize `closingCharactersMap` instead of hard-coding all the separate characters
+- Added auto-closing via a characterMap
+    - Changed the event listener for auto-closing brackets to utilize `closingCharactersMap` instead of hard-coding all the separate characters
+```js
+const closingCharactersMap {
+  '(': ')',
+  '{': '}',
+  '[': ']',
+  '`': '`',
+  '$': '$',
+  '*': '*',
+  '_': '_',
+}
+```
+- Added context menu for file deletion and file renaming
+    - Must still make it functional, current functionality is only viewing the menu upon right-clicking a file
+- Added better documentation to `render.js`
 
 # today's goals
 ---
@@ -23,7 +37,6 @@
 # to-be-implemented
 ---
 - Make rendering dynamic
-- Make the app zoomable
 - UI for note outline (makes note navigable)
 - Read-only mode
 - UI for folder creation, deletion, and renaming
@@ -37,9 +50,9 @@
         
 # demo
 ---
-I really like making inline LaTeX... $\sum_{k = 1}^n \frac{1}{k(k + 1)} = \frac{n}{n + 1}$
+Inline LaTeX $\sum_{k = 1}^n \frac{1}{k(k + 1)} = \frac{n}{n + 1}$
 
-I really like making nice looking code blocks using `Atom One Dark` theme...
+Code blocks
 ```js
 function handleImageFile(file) {
     // Upload file to the system and get the URL or embed HTML
@@ -47,4 +60,9 @@ function handleImageFile(file) {
     const imageURL = "https://example.com/images/image.jpg";
     const embedHTML = `<img src="${imageURL}" alt ="Pasted image"/>`;
     insertTextAtCursor(editor, embedHTML);
-``
+```
+## h2
+### h3
+#### h4
+##### h5
+###### h6

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,34 @@ a:visited {
   margin: 10px;
   cursor: pointer;
 }
+
+/* context menu upon right click on noteList to display delete and rename*/
+#contextMenuNoteList {
+  position: fixed;
+  z-index: 10000;
+  width: 150px;
+  background: var(--blockquote-border);
+  border-radius: 5px;
+  display: none;
+}
+
+#contextMenuNoteList.visible {
+  display: block;
+}
+
+#contextMenuNoteList .contextMenuNoteListItem{
+  padding: 8px 10px;
+  font-size: 15px;
+  color: var(--text-normal);
+  cursor: pointer;
+  border-radius: 5px;
+  border-top: none;
+}
+
+#contextMenuNoteList .contextMenuNoteListItem:first-child {
+  border-top: 5px;
+}
+
+#contextMenuNoteList .contextMenuNoteListItem:hover {
+  background: var(--background-code);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -16,5 +16,10 @@
     </div>
     <textarea id="editor"></textarea>
     <div id="outputField"></div>
+    <!-- context menu for deleting and renaming files -->
+    <div id="contextMenuNoteList">
+      <div class="contextMenuNoteListItem" id = "deleteOption">Delete</div>
+      <div class="contextMenuNoteListItem" id = "renameOption">Rename</div>
+    </div>
   </body>
 </html>

--- a/src/render.js
+++ b/src/render.js
@@ -21,6 +21,12 @@ const md = require('markdown-it')({
     errorColor: '#cc0000'
 });
 
+/**
+ * =======================================
+ *           MARKDOWN RENDERING
+ * =======================================
+ */
+
 const editor = document.getElementById('editor');
 const outputField = document.getElementById('outputField');
 let selectedFilePath = null;      // store the currently selected Markdown file path
@@ -36,6 +42,12 @@ const renderMarkdown = () => {
     outputField.innerHTML = renderedHTML;
   }, 300); // 300 ms delay to optimize rendering performance
 };
+
+/**
+ * =======================================
+ *             FILE WATCHING
+ * =======================================
+ */
 
 // Function to handle file changes
 const handleFileChange = (eventType, filename) => {
@@ -82,6 +94,12 @@ const saveMarkdownToFile = () => {
     }
   },300);
 };
+
+/**
+ * =============================================================================
+ *           EVENT LISTENERS FOR MARKDOWN RENDERING AND FILE WATCHING
+ * =============================================================================
+ */
 
 // Add event listener to the editor for input changes
 editor.addEventListener('input', () => {
@@ -177,6 +195,11 @@ editor.addEventListener('keydown', (event) => {
 // by default, editor is disabled until a user selects a file
 editor.disabled = true;
 
+/**
+ * =======================================
+ *             FILE EXPLORER
+ * =======================================
+ */
 const fileList = document.getElementById('fileList');
 // list all MD files and update in real time when files are added or removed or renamed
 const listMDFiles = () => {
@@ -241,4 +264,36 @@ fs.watch('./src', (eventType, filename) => {
   }
 });
 
+/**
+ * ===========================================================
+ *              EVENT LISTENERS FOR FILE EXPLORER
+ * ===========================================================
+ */
+
+// hold a reference to contextMenuNoteList and ensure that the scope is noteList
+const contextMenuNoteList = document.getElementById('contextMenuNoteList');
+const noteList = document.getElementById('noteList');
+
+// Upon right click on a file in the list, show the context menu at the mouse position
+noteList.addEventListener('contextmenu', (event) => {
+  const { target } = event;
+  if (target.tagName === 'SPAN') {
+    event.preventDefault();
+
+    const { clientX: mouseX, clientY: mouseY } = event;
+    contextMenuNoteList.style.top = `${mouseY}px`;
+    contextMenuNoteList.style.left = `${mouseX}px`;
+
+    contextMenuNoteList.classList.add('visible');
+  }
+});
+
+// If the user clicks outside the context menu, hide it
+document.addEventListener('click', (event) => {
+  if (event.target.offsetParent != contextMenuNoteList) {
+    contextMenuNoteList.classList.remove('visible');
+  }
+});
+
+// List MD files upon page load
 listMDFiles();


### PR DESCRIPTION
- Changed code font from `Consolas` to `Fira Code`
    - Inline code remains as is, i.e. `Ubuntu Mono`
    - Inline code now has padding and background color
    - Changed padding for code blocks from `7px` to `5px`
- Modified the event listener for enter to ensure that Markdown is rendered and saved to file after enter key press
- Fixed highlighting of Notes tab to only highlight text content by making a list of spans and changed the event listener on `fileList` to look for `if (target.tagName === 'SPAN')` instead of looking for `tagName === 'LI'`
- Added auto-closing via a characterMap
    - Changed the event listener for auto-closing brackets to utilize `closingCharactersMap` instead of hard-coding all the separate characters
```js
const closingCharactersMap {
  '(': ')',
  '{': '}',
  '[': ']',
  '`': '`',
  '$': '$',
  '*': '*',
  '_': '_',
}
```
- Added context menu for file deletion and file renaming
    - Must still make it functional, current functionality is only viewing the menu upon right-clicking a file
- Added better documentation to `render.js`