### PR TITLE
Styling and code flair

### DIFF
--- a/src/6-05-2023-log.md
+++ b/src/6-05-2023-log.md
@@ -1,0 +1,18 @@
+# changes
+---
+- Moved `noteList` to left side
+- `editor` and `outputField` are displayed side-by-side (instead of top-and-bottom)
+- Added code language flair to right corner of code blocks
+
+# to-do
+---
+- Change side-by-side live preview to "Source mode" and "Read mode"
+    - Source mode displays RAW markdown contents and ALLOWS editing
+    - Read mode displays RENDERED Markdown contents and DISABLES editing
+        - `Ctrl + E` or `Cmd + E` to toggle modes
+    - Must ensure that current cursor position AND current scroll position is preserved when toggling modes
+
+# issues
+---
+- Selection cursor autoamtically goes to the end of the Markdown file when you type characters 300ms apart
+    - 300ms is the length of the debounce timer for `saveMarkdownToFile()`

--- a/src/index.css
+++ b/src/index.css
@@ -23,13 +23,14 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
-    Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   margin: auto;
-  max-width: 38rem;
+  width: 60rem;
   padding: 2rem;
   background-color: var(--background);
   color: var(--text-normal);
+  display: flex; /* Use flex display for the body */
+  justify-content: center; /* Center the divs horizontally */
 }
 
 h1 {
@@ -57,36 +58,48 @@ h6 {
 }
 
 /* custom scrollbar */
-#editor::-webkit-scrollbar {
+#editor::-webkit-scrollbar, #outputField::-webkit-scrollbar {
   width: 5px;
 }
 
-#editor::-webkit-scrollbar-track {
+#editor::-webkit-scrollbar-track, #outputField::-webkit-scrollbar-track {
   background-color: transparent;
 }
 
-#editor::-webkit-scrollbar-thumb {
+#editor::-webkit-scrollbar-thumb, #outputField::-webkit-scrollbar-thumb {
   background-color: #888;
   border-radius: 5px;
   min-height: 50px;
 }
 
-#editor::-webkit-scrollbar-thumb:hover {
+#editor::-webkit-scrollbar-thumb:hover, #outputField::-webkit-scrollbar-thumb:hover {
   background-color: #555;
 }
 
+/* editor and output fields */
+#contentField {
+  display: flex;
+  justify-content: center;
+  padding: 2rem; /* Adjust the padding value as needed */
+}
+
 #editor {
+  flex: 1;
   border: transparent;
   outline: none;
   font-family: 'Ubuntu', monospace;
   font-size: 24px;
-  height: 200px;
-  width: 800px;
-  overflow: hidden;
   overflow-y: scroll;
   color: var(--text-normal);
   background-color: transparent;
   resize: none;
+  margin-right: 10px;
+}
+
+#outputField {
+  flex: 1;
+  margin-right: 10px;
+  overflow-y: scroll;
 }
 
 /* for code blocks */
@@ -113,12 +126,7 @@ p code, li code {
   border-radius: 3px;
 }
 
-#outputField {
-  margin: auto;
-  max-width: 38rem;
-  padding: 2rem;
-  position: relative;
-}
+/* links */
 
 a {
   color: var(--text-link);
@@ -136,16 +144,23 @@ a:visited {
   color: var(--text-a);
 }
 
+/* file explorer (*/
 #noteList {
+  position: fixed;
+  top: 50px; /* Adjust the top position as per your preference */
+  left: 25px; /* Adjust the left position as per your preference */
+  width: 200px; /* Adjust the width as per your preference */
+  height: calc(100vh - 100px); /* Adjust the height as per your preference */
   background: var(--menu-background);
   border: 1px solid var(--menu-border);
   border-radius: 5px;
   padding: 5px;
-  margin: 25px 25px;
+  overflow-y: auto; /* Enable vertical scrolling if content exceeds the height */
+  overflow-x: hidden;
 }
 
 #fileList {
-  margin: 25px 25px;
+  margin: 20px 0px 20px 10px;
 }
 
 #fileList .selected {
@@ -164,9 +179,12 @@ a:visited {
   padding-left: 30px;
   margin: 10px;
   cursor: pointer;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-/* context menu upon right click on noteList to display delete and rename*/
+/* context menu */
 #contextMenuNoteList {
   position: fixed;
   z-index: 10000;
@@ -227,7 +245,13 @@ a:visited {
   line-height: normal;
 }
 
-.code-language {
+/* display code flair on top right of code blocks */
+.code-flair {
+  display: inline-block;
   position: relative;
-  padding: 0.25em 0.5em;
+  top: 0;
+  left: 95%;
+  padding: 2px 4px;
+  font-size: 12px;
+  font-weight: bold;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -31,8 +31,10 @@
       </div>
       <ul id="fileList"></ul>
     </div>
-    <textarea id="editor"></textarea>
-    <div id="outputField"></div>
+    <div id="contentField">
+      <textarea id="editor"></textarea>
+      <div id="outputField"></div>
+    </div>
     <!-- context menu for file operations -->
     <div id="contextMenuNoteList">
       <div class="contextMenuNoteListItem" id="deleteOption">

--- a/src/test-new-rendering.md
+++ b/src/test-new-rendering.md
@@ -1,0 +1,12 @@
+# changes
+---
+- Changed "Live preview" to "Source mode + Read-only mode"
+    - Philosophy changed from WYSIWYG to WYSIWYM, then you can see rendered markdown upon `Ctrl + E || Cmd + E`
+    
+- This significantly improves user experience for those who like WYSIYWM... but not much so for those who like WYSIWYG... too bad... i guess
+
+```js
+const add = (x, y) => {
+    return x+y
+}
+```

--- a/src/test-syntax-and-latex.md
+++ b/src/test-syntax-and-latex.md
@@ -1,4 +1,4 @@
-# LaTeX Test
+# Test LaTeX
 ---
 $$\sum_{k = 1}^n \frac{1}{k(k + 1)} = \frac{n}{n + 1}$$
 

--- a/src/test.md
+++ b/src/test.md
@@ -1,0 +1,4 @@
+```py
+    def add(x, y):
+        return x+y
+```


### PR DESCRIPTION
# changes
---
- Moved `noteList` to left side
- `editor` and `outputField` are displayed side-by-side (instead of top-and-bottom)
- Added code language flair to right corner of code blocks

# to-do
---
- Change side-by-side live preview to "Source mode" and "Read mode"
    - Source mode displays RAW markdown contents and ALLOWS editing
    - Read mode displays RENDERED Markdown contents and DISABLES editing
        - `Ctrl + E` or `Cmd + E` to toggle modes
    - Must ensure that current cursor position is preserved when toggling modes
    - Must ensure that current scroll position is preserved when toggling modes
        - Since Source mode will NOT display images, but Read mode will, it is COMPLETELY OKAY for scroll position to be different when you are toggling modes when an image is in view

# issues
---
- Selection cursor autoamtically goes to the end of the Markdown file when you type characters 300ms apart
    - 300ms is the length of the debounce timer for `saveMarkdownToFile()`
